### PR TITLE
[feat-1220]: Валидация входных данных

### DIFF
--- a/src/main/java/io/hexlet/cv/config/JacksonConfig.java
+++ b/src/main/java/io/hexlet/cv/config/JacksonConfig.java
@@ -1,6 +1,7 @@
 package io.hexlet.cv.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
@@ -46,6 +47,7 @@ public class JacksonConfig {
         mapper.registerModule(javaTimeModule);
 
         mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
         return mapper;
     }
@@ -78,6 +80,7 @@ public class JacksonConfig {
 
         return builder.serializationInclusion(JsonInclude.Include.NON_NULL)
                 .modules(new JsonNullableModule(), configuredModule)
-                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .featuresToEnable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
     }
 }

--- a/src/main/java/io/hexlet/cv/config/LocaleConfig.java
+++ b/src/main/java/io/hexlet/cv/config/LocaleConfig.java
@@ -45,7 +45,10 @@ public class LocaleConfig implements WebMvcConfigurer {
     @Bean
     public MessageSource messageSource() {
         ResourceBundleMessageSource ms = new ResourceBundleMessageSource();
-        ms.setBasenames("messages/messages");
+        ms.setBasenames(
+                "messages/common/messages",
+                "messages/validation/messages"
+        );
         ms.setDefaultEncoding("UTF-8");
         ms.setUseCodeAsDefaultMessage(false);
         return ms;

--- a/src/main/java/io/hexlet/cv/dto/marketing/ArticleCreateDto.java
+++ b/src/main/java/io/hexlet/cv/dto/marketing/ArticleCreateDto.java
@@ -3,18 +3,27 @@ package io.hexlet.cv.dto.marketing;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
 
 @Getter
 @Setter
 public class ArticleCreateDto {
-    @NotBlank(message = "Title is required")
-    private String title;
 
     @NotBlank(message = "Title is required")
+    @Size(max = 255, message = "Title must not exceed 255 characters")
+    private String title;
+
+    @NotBlank(message = "Content is required")
+    @Size(max = 50000, message = "Content must not exceed 50000 characters")
     private String content;
+
+    @URL(message = "Image URL must be valid")
     private String imageUrl;
+
+    @Size(max = 255, message = "Author must not exceed 255 characters")
     private String author;
 
     @Min(value = 1, message = "Reading time must be at least 1 minute")
@@ -22,6 +31,8 @@ public class ArticleCreateDto {
 
     @NotNull(message = "Published status is required")
     private Boolean isPublished = false;
+
+    @Size(max = 255, message = "Home component ID must not exceed 255 characters")
     private String homeComponentId;
 
     @NotNull(message = "Homepage visibility is required")

--- a/src/main/java/io/hexlet/cv/dto/marketing/ArticleUpdateDto.java
+++ b/src/main/java/io/hexlet/cv/dto/marketing/ArticleUpdateDto.java
@@ -1,19 +1,38 @@
 package io.hexlet.cv.dto.marketing;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 @Getter
 @Setter
 public class ArticleUpdateDto {
+
+    @Size(max = 255, message = "Title must not exceed 255 characters")
     private JsonNullable<String> title;
+
+    @Size(max = 50000, message = "Content must not exceed 50000 characters")
     private JsonNullable<String> content;
+
+    @URL(message = "Image URL must be valid")
     private JsonNullable<String> imageUrl;
+
+    @Size(max = 255, message = "Author must not exceed 255 characters")
     private JsonNullable<String> author;
+
+    @Min(value = 1, message = "Reading time must be at least 1 minute")
     private JsonNullable<Integer> readingTime;
+
     private JsonNullable<Boolean> isPublished;
+
+    @Size(max = 255, message = "Home component ID must not exceed 255 characters")
     private JsonNullable<String> homeComponentId;
+
     private JsonNullable<Boolean> showOnHomepage;
+
+    @Min(value = 0, message = "Display order must be positive")
     private JsonNullable<Integer> displayOrder;
 }

--- a/src/main/java/io/hexlet/cv/dto/marketing/ReviewCreateDto.java
+++ b/src/main/java/io/hexlet/cv/dto/marketing/ReviewCreateDto.java
@@ -3,6 +3,7 @@ package io.hexlet.cv.dto.marketing;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.URL;
@@ -11,9 +12,11 @@ import org.hibernate.validator.constraints.URL;
 @Setter
 public class ReviewCreateDto {
     @NotBlank(message = "Author name is required")
+    @Size(max = 255, message = "Author name must not exceed 255 characters")
     private String author;
 
     @NotBlank(message = "Review content is required")
+    @Size(max = 10000, message = "Content must not exceed 10000 characters")
     private String content;
 
     @URL(message = "Avatar URL must be valid")

--- a/src/main/java/io/hexlet/cv/dto/marketing/ReviewUpdateDto.java
+++ b/src/main/java/io/hexlet/cv/dto/marketing/ReviewUpdateDto.java
@@ -1,16 +1,29 @@
 package io.hexlet.cv.dto.marketing;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 @Getter
 @Setter
 public class ReviewUpdateDto {
+
+    @Size(max = 255, message = "Author name must not exceed 255 characters")
     private JsonNullable<String> author;
+
+    @Size(max = 10000, message = "Content must not exceed 10000 characters")
     private JsonNullable<String> content;
+
+    @URL(message = "Avatar URL must be valid")
     private JsonNullable<String> avatarUrl;
+
     private JsonNullable<Boolean> isPublished;
+
     private JsonNullable<Boolean> showOnHomepage;
+
+    @Min(value = 0, message = "Display order must be positive")
     private JsonNullable<Integer> displayOrder;
 }

--- a/src/main/java/io/hexlet/cv/dto/marketing/StoryCreateDto.java
+++ b/src/main/java/io/hexlet/cv/dto/marketing/StoryCreateDto.java
@@ -3,6 +3,7 @@ package io.hexlet.cv.dto.marketing;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.URL;
@@ -11,13 +12,16 @@ import org.hibernate.validator.constraints.URL;
 @Setter
 public class StoryCreateDto {
     @NotBlank(message = "Title is required")
+    @Size(max = 255, message = "Title must not exceed 255 characters")
     private String title;
 
     @NotBlank(message = "Content is required")
+    @Size(max = 50000, message = "Content must not exceed 50000 characters")
     private String content;
 
     @URL(message = "Image URL must be valid")
     private String imageUrl;
+
     private Boolean isPublished = false;
 
     @NotNull(message = "Homepage visibility is required")

--- a/src/main/java/io/hexlet/cv/dto/marketing/StoryUpdateDto.java
+++ b/src/main/java/io/hexlet/cv/dto/marketing/StoryUpdateDto.java
@@ -1,17 +1,29 @@
 package io.hexlet.cv.dto.marketing;
 
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 @Getter
 @Setter
 public class StoryUpdateDto {
 
+    @Size(max = 255, message = "Title must not exceed 255 characters")
     private JsonNullable<String> title;
+
+    @Size(max = 50000, message = "Content must not exceed 50000 characters")
     private JsonNullable<String> content;
+
+    @URL(message = "Image URL must be valid")
     private JsonNullable<String> imageUrl;
+
     private JsonNullable<Boolean> isPublished;
+
     private JsonNullable<Boolean> showOnHomepage;
+
+    @Min(value = 0, message = "Display order must be positive")
     private JsonNullable<Integer> displayOrder;
 }

--- a/src/main/java/io/hexlet/cv/dto/marketing/TeamCreateDto.java
+++ b/src/main/java/io/hexlet/cv/dto/marketing/TeamCreateDto.java
@@ -5,6 +5,7 @@ import io.hexlet.cv.model.enums.TeamPosition;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.URL;
@@ -13,9 +14,11 @@ import org.hibernate.validator.constraints.URL;
 @Setter
 public class TeamCreateDto {
     @NotBlank(message = "First name is required")
+    @Size(max = 255, message = "First name must not exceed 255 characters")
     private String firstName;
 
     @NotBlank(message = "Last name is required")
+    @Size(max = 255, message = "Last name must not exceed 255 characters")
     private String lastName;
 
     @NotNull(message = "Position is required")

--- a/src/main/java/io/hexlet/cv/dto/marketing/TeamUpdateDto.java
+++ b/src/main/java/io/hexlet/cv/dto/marketing/TeamUpdateDto.java
@@ -2,20 +2,34 @@ package io.hexlet.cv.dto.marketing;
 
 import io.hexlet.cv.model.enums.TeamMemberType;
 import io.hexlet.cv.model.enums.TeamPosition;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.URL;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 @Getter
 @Setter
 public class TeamUpdateDto {
 
+    @Size(max = 255, message = "First name must not exceed 255 characters")
     private JsonNullable<String> firstName;
+
+    @Size(max = 255, message = "Last name must not exceed 255 characters")
     private JsonNullable<String> lastName;
+
     private JsonNullable<TeamPosition> position;
+
     private JsonNullable<TeamMemberType> memberType;
+
+    @URL(message = "Avatar URL must be valid")
     private JsonNullable<String> avatarUrl;
+
     private JsonNullable<Boolean> isPublished;
+
     private JsonNullable<Boolean> showOnHomepage;
+
+    @Min(value = 0, message = "Display order must be positive")
     private JsonNullable<Integer> displayOrder;
 }

--- a/src/main/java/io/hexlet/cv/dto/pagesection/PageSectionCreateDTO.java
+++ b/src/main/java/io/hexlet/cv/dto/pagesection/PageSectionCreateDTO.java
@@ -1,20 +1,26 @@
 package io.hexlet.cv.dto.pagesection;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Data;
 
 @Data
 public class PageSectionCreateDTO {
 
     // "main", "profile" и др.
-    @NotBlank(message = "Техническое название страницы с секцией обязательно")
+    @NotBlank(message = "Page key is required")
+    @Size(max = 255, message = "Page key must not exceed 255 characters")
     private String pageKey;
 
     // "about_us", "team", "pricing" и др.
-    @NotBlank(message = "Техническое название секции обязательно")
+    @NotBlank(message = "Section key is required")
+    @Size(max = 255, message = "Section key must not exceed 255 characters")
     private String sectionKey;
 
+    @Size(max = 255, message = "Title must not exceed 255 characters")
     private String title;
+
+    @Size(max = 50000, message = "Content must not exceed 50000 characters")
     private String content;
 
     // Можно не указывать, включена ли секция - сервис установит true по умолчанию

--- a/src/main/java/io/hexlet/cv/dto/pagesection/PageSectionUpdateDTO.java
+++ b/src/main/java/io/hexlet/cv/dto/pagesection/PageSectionUpdateDTO.java
@@ -2,6 +2,7 @@ package io.hexlet.cv.dto.pagesection;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -13,12 +14,16 @@ import org.openapitools.jackson.nullable.JsonNullable;
 public class PageSectionUpdateDTO {
 
     @NotBlank(message = "Техническое название страницы с секцией обязательно")
+    @Size(max = 255, message = "Page key must not exceed 255 characters")
     private JsonNullable<String> pageKey;
 
     @NotBlank(message = "Техническое название обязательно")
+    @Size(max = 255, message = "Section key must not exceed 255 characters")
     private JsonNullable<String> sectionKey;
 
+    @Size(max = 255, message = "Title must not exceed 255 characters")
     private JsonNullable<String> title;
+    @Size(max = 50000, message = "Content must not exceed 50000 characters")
     private JsonNullable<String> content;
 
     @NotNull(message = "Статус активности секции обязателен")

--- a/src/main/java/io/hexlet/cv/dto/user/auth/LoginRequestDTO.java
+++ b/src/main/java/io/hexlet/cv/dto/user/auth/LoginRequestDTO.java
@@ -12,10 +12,11 @@ public class LoginRequestDTO {
 
     @NotBlank(message = "{email.notBlank}")
     @Email(message = "{email.invalid}")
+    @Size(max = 255, message = "{email.maxSize}")
     private String email;
 
     @NotBlank(message = "{password.notBlank}")
-    @Size(min = 8, message = "{password.minSize}")
+    @Size(min = 8, max = 255, message = "{password.size}")
     private String password;
 
 

--- a/src/main/java/io/hexlet/cv/dto/user/auth/RegistrationRequestDTO.java
+++ b/src/main/java/io/hexlet/cv/dto/user/auth/RegistrationRequestDTO.java
@@ -22,17 +22,20 @@ public class RegistrationRequestDTO {
     @EmailNotWithSingleCharTld
     @NotInDisposableEmailDomains
     @EmailDomainViaDnsApi
+    @Size(max = 255, message = "{email.maxSize}")
     private String email;
 
     @NotBlank(message = "{password.notBlank}")
-    @Size(min = 8, message = "{password.minSize}")
+    @Size(min = 8, max = 255, message = "{password.size}")
     @NotInTop10K
     private String password;
 
     @NotBlank(message = "{user.firstName.notBlank}")
+    @Size(max = 255, message = "{user.firstName.maxSize}")
     private String firstName;
 
     @NotBlank(message = "{user.lastName.notBlank}")
+    @Size(max = 255, message = "{user.lastName.maxSize}")
     private String lastName;
 
     @NotNull(message = "{user.terms.required}")

--- a/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
+++ b/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -101,11 +102,16 @@ public class GlobalExceptionHandler {
                                    RedirectAttributes redirectAttributes) {
 
         Map<String, String> errors = new HashMap<>();
+
         for (FieldError error : ex.getBindingResult().getFieldErrors()) {
             errors.put(error.getField(), error.getDefaultMessage());
         }
 
-        return commonHandle(errors, request, redirectAttributes, HttpStatus.UNPROCESSABLE_ENTITY);
+        for (ObjectError error : ex.getBindingResult().getGlobalErrors()) {
+            errors.put(error.getObjectName(), error.getDefaultMessage());
+        }
+
+        return commonHandle(errors, request, redirectAttributes, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(UserAlreadyExistsException.class)

--- a/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
+++ b/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package io.hexlet.cv.handler;
 
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import io.hexlet.cv.handler.exception.InvalidPasswordException;
 import io.hexlet.cv.handler.exception.ResourceNotFoundException;
 import io.hexlet.cv.handler.exception.UserAlreadyExistsException;
@@ -53,7 +54,14 @@ public class GlobalExceptionHandler {
 
         String errorMessage = "Invalid JSON format";
 
-        if (ex.getCause() instanceof InvalidFormatException) {
+        if (ex.getCause() instanceof UnrecognizedPropertyException cause) {
+
+            errorMessage = String.format(
+                    "Unknown property '%s' is not allowed",
+                    cause.getPropertyName()
+            );
+
+        } else if (ex.getCause() instanceof InvalidFormatException) {
             InvalidFormatException cause = (InvalidFormatException) ex.getCause();
             if (cause.getTargetType().isEnum()) {
                 Class<? extends Enum> enumClass = (Class<? extends Enum>) cause.getTargetType();

--- a/src/main/resources/messages/common/messages_en.properties
+++ b/src/main/resources/messages/common/messages_en.properties
@@ -1,0 +1,14 @@
+newsletter.settings.updated=Settings updated successfully
+
+password.invalid=Invalid password
+
+user.alreadyExists=User with this email already exists
+user.notFound=User not found
+user.notFound.description=User with ID {0} does not exist in the system
+
+login.success=Login successful
+login.error=Invalid email or password
+
+registration.success=Registration completed successfully
+
+logout.success=You have successfully logged out

--- a/src/main/resources/messages/common/messages_ru.properties
+++ b/src/main/resources/messages/common/messages_ru.properties
@@ -1,0 +1,14 @@
+newsletter.settings.updated=Настройки успешно обновлены
+
+password.invalid=Неверный пароль
+
+user.alreadyExists=Пользователь с таким email уже существует
+user.notFound=Пользователь не найден
+user.notFound.description=Пользователь с ID {0} не существует в системе
+
+login.success=Вход выполнен успешно
+login.error=Неверный email или пароль
+
+registration.success=Регистрация успешно завершена
+
+logout.success=Вы успешно вышли из системы

--- a/src/main/resources/messages/messages_en.properties
+++ b/src/main/resources/messages/messages_en.properties
@@ -3,12 +3,13 @@ email.invalid=Please provide a valid email address
 email.domain.not.exists=Email domain does not exist
 email.tld.minSize=Email TLD must be at least 2 characters long
 email.disposable=Disposable email addresses are not allowed
+email.maxSize=Email must not exceed 255 characters
 
 newsletter.settings.updated=Settings updated successfully
 
 password.top10k=Password is too common
 password.notBlank=Password is required
-password.minSize=Password must be at least 8 characters
+password.size=Password must be between 8 and 255 characters
 password.notSimilar=Password is too simple — must not match email or name
 password.invalid=Invalid password
 
@@ -19,6 +20,8 @@ user.notFound=User not found
 user.notFound.description=User with ID {0} does not exist in the system
 user.terms.required=Terms acceptance is required
 user.terms.accepted=You must accept the terms
+user.firstName.maxSize=First name must not exceed 255 characters
+user.lastName.maxSize=Last name must not exceed 255 characters
 
 login.success=Login successful
 login.error=Invalid email or password

--- a/src/main/resources/messages/messages_ru.properties
+++ b/src/main/resources/messages/messages_ru.properties
@@ -3,12 +3,13 @@ email.invalid=Укажите корректный email-адрес
 email.domain.not.exists=Домен в email не существует
 email.tld.minSize=TLD email должен содержать как минимум 2 символа
 email.disposable=Запрещено использовать одноразовые email
+email.maxSize=Email не должен превышать 255 символов
 
 newsletter.settings.updated=Настройки успешно обновлены
 
 password.top10k=Слишком распространённый пароль
 password.notBlank=Пароль обязателен
-password.minSize=Пароль должен быть не менее 8 символов
+password.size=Пароль должен содержать от 8 до 255 символов
 password.notSimilar=Пароль слишком простой — не должен совпадать с email или именем
 password.invalid=Неверный пароль
 
@@ -19,6 +20,8 @@ user.notFound=Пользователь не найден
 user.notFound.description=Пользователь с ID {0} не существует в системе
 user.terms.required=Необходимо указать согласие с условиями
 user.terms.accepted=Необходимо принять условия
+user.firstName.maxSize=Имя не должно превышать 255 символов
+user.lastName.maxSize=Фамилия не должна превышать 255 символов
 
 login.success=Вход выполнен успешно
 login.error=Неверный email или пароль

--- a/src/main/resources/messages/validation/messages_en.properties
+++ b/src/main/resources/messages/validation/messages_en.properties
@@ -5,27 +5,14 @@ email.tld.minSize=Email TLD must be at least 2 characters long
 email.disposable=Disposable email addresses are not allowed
 email.maxSize=Email must not exceed 255 characters
 
-newsletter.settings.updated=Settings updated successfully
-
 password.top10k=Password is too common
 password.notBlank=Password is required
 password.size=Password must be between 8 and 255 characters
 password.notSimilar=Password is too simple — must not match email or name
-password.invalid=Invalid password
 
 user.firstName.notBlank=First name is required
 user.lastName.notBlank=Last name is required
-user.alreadyExists=User with this email already exists
-user.notFound=User not found
-user.notFound.description=User with ID {0} does not exist in the system
 user.terms.required=Terms acceptance is required
 user.terms.accepted=You must accept the terms
 user.firstName.maxSize=First name must not exceed 255 characters
 user.lastName.maxSize=Last name must not exceed 255 characters
-
-login.success=Login successful
-login.error=Invalid email or password
-
-registration.success=Registration completed successfully
-
-logout.success=You have successfully logged out

--- a/src/main/resources/messages/validation/messages_ru.properties
+++ b/src/main/resources/messages/validation/messages_ru.properties
@@ -5,27 +5,14 @@ email.tld.minSize=TLD email должен содержать как миниму�
 email.disposable=Запрещено использовать одноразовые email
 email.maxSize=Email не должен превышать 255 символов
 
-newsletter.settings.updated=Настройки успешно обновлены
-
 password.top10k=Слишком распространённый пароль
 password.notBlank=Пароль обязателен
 password.size=Пароль должен содержать от 8 до 255 символов
 password.notSimilar=Пароль слишком простой — не должен совпадать с email или именем
-password.invalid=Неверный пароль
 
 user.firstName.notBlank=Имя обязательно
 user.lastName.notBlank=Фамилия обязательна
-user.alreadyExists=Пользователь с таким email уже существует
-user.notFound=Пользователь не найден
-user.notFound.description=Пользователь с ID {0} не существует в системе
 user.terms.required=Необходимо указать согласие с условиями
 user.terms.accepted=Необходимо принять условия
 user.firstName.maxSize=Имя не должно превышать 255 символов
 user.lastName.maxSize=Фамилия не должна превышать 255 символов
-
-login.success=Вход выполнен успешно
-login.error=Неверный email или пароль
-
-registration.success=Регистрация успешно завершена
-
-logout.success=Вы успешно вышли из системы

--- a/src/test/java/io/hexlet/cv/controller/PricingPlanControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/PricingPlanControllerTest.java
@@ -230,7 +230,7 @@ public class PricingPlanControllerTest {
                         .cookie(new Cookie("access_token", adminToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(invalidPricingJson))
-                .andExpect(status().isUnprocessableEntity());
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/io/hexlet/cv/controller/RegistrationControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/RegistrationControllerTest.java
@@ -94,7 +94,7 @@ public class RegistrationControllerTest {
         mockMvc.perform(post("/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.errors.email").exists());
     }
@@ -129,7 +129,7 @@ public class RegistrationControllerTest {
         mockMvc.perform(post("/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.errors.email").exists());
     }
@@ -145,7 +145,7 @@ public class RegistrationControllerTest {
         mockMvc.perform(post("/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.errors.email").exists());
     }
@@ -181,7 +181,7 @@ public class RegistrationControllerTest {
         mockMvc.perform(post("/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.errors.password").exists());
     }
@@ -194,7 +194,7 @@ public class RegistrationControllerTest {
         mockMvc.perform(post("/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.password").exists());
 
         // фамилия совпадает
@@ -202,7 +202,7 @@ public class RegistrationControllerTest {
         mockMvc.perform(post("/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.password").exists());
 
         // email совпадает
@@ -210,7 +210,7 @@ public class RegistrationControllerTest {
         mockMvc.perform(post("/users")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(om.writeValueAsString(data)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.password").exists());
     }
 

--- a/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingArticlesControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingArticlesControllerTest.java
@@ -1,13 +1,5 @@
 package io.hexlet.cv.controller.admin.marketing;
 
-import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
-import io.hexlet.cv.dto.marketing.ArticleCreateDto;
-import io.hexlet.cv.dto.marketing.ArticleUpdateDto;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.openapitools.jackson.nullable.JsonNullable;
-import org.springframework.http.MediaType;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -18,6 +10,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
+import io.hexlet.cv.dto.marketing.ArticleCreateDto;
+import io.hexlet.cv.dto.marketing.ArticleUpdateDto;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.http.MediaType;
 
 /**
  * Создание и обновление статей через {@code POST/PUT /admin/marketing/articles}:
@@ -57,7 +57,7 @@ public class AdminMarketingArticlesControllerTest extends AdminMarketingControll
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.title").exists());
     }
 
@@ -72,7 +72,7 @@ public class AdminMarketingArticlesControllerTest extends AdminMarketingControll
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.content").exists());
     }
 

--- a/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingCommonControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingCommonControllerTest.java
@@ -1,17 +1,5 @@
 package io.hexlet.cv.controller.admin.marketing;
 
-import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.mockito.ArgumentCaptor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.http.MediaType;
-
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
@@ -25,6 +13,17 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
 
 /**
  * Общие маршруты {@code AdminMarketingController}, не привязанные к одной сущности:
@@ -217,7 +216,7 @@ public class AdminMarketingCommonControllerTest extends AdminMarketingController
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(body))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.displayOrder").exists());
     }
 
@@ -230,7 +229,7 @@ public class AdminMarketingCommonControllerTest extends AdminMarketingController
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(body))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity());
+                .andExpect(status().isBadRequest());
     }
 
     @Test

--- a/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingPricingControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingPricingControllerTest.java
@@ -1,13 +1,5 @@
 package io.hexlet.cv.controller.admin.marketing;
 
-import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
-import io.hexlet.cv.dto.marketing.PricingCreateDto;
-import io.hexlet.cv.dto.marketing.PricingUpdateDto;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.openapitools.jackson.nullable.JsonNullable;
-import org.springframework.http.MediaType;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -18,6 +10,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
+import io.hexlet.cv.dto.marketing.PricingCreateDto;
+import io.hexlet.cv.dto.marketing.PricingUpdateDto;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.http.MediaType;
 
 /**
  * Создание и обновление тарифов через {@code POST/PUT /admin/marketing/pricing}:
@@ -58,7 +58,7 @@ public class AdminMarketingPricingControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.name").exists());
     }
 
@@ -74,7 +74,7 @@ public class AdminMarketingPricingControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.originalPrice").exists());
     }
 
@@ -90,7 +90,7 @@ public class AdminMarketingPricingControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.discountPercent").exists());
     }
 
@@ -106,7 +106,7 @@ public class AdminMarketingPricingControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.discountPercent").exists());
     }
 
@@ -122,7 +122,7 @@ public class AdminMarketingPricingControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.name").exists());
     }
 
@@ -151,7 +151,7 @@ public class AdminMarketingPricingControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.discountPercent").exists());
     }
 }

--- a/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingReviewsControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingReviewsControllerTest.java
@@ -1,13 +1,5 @@
 package io.hexlet.cv.controller.admin.marketing;
 
-import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
-import io.hexlet.cv.dto.marketing.ReviewCreateDto;
-import io.hexlet.cv.dto.marketing.ReviewUpdateDto;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.openapitools.jackson.nullable.JsonNullable;
-import org.springframework.http.MediaType;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -18,6 +10,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
+import io.hexlet.cv.dto.marketing.ReviewCreateDto;
+import io.hexlet.cv.dto.marketing.ReviewUpdateDto;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.http.MediaType;
 
 /**
  * Создание и обновление отзывов через {@code POST/PUT /admin/marketing/reviews}:
@@ -56,7 +56,7 @@ public class AdminMarketingReviewsControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.author").exists());
     }
 
@@ -72,7 +72,7 @@ public class AdminMarketingReviewsControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.avatarUrl").exists());
     }
 

--- a/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingStoriesControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingStoriesControllerTest.java
@@ -1,13 +1,5 @@
 package io.hexlet.cv.controller.admin.marketing;
 
-import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
-import io.hexlet.cv.dto.marketing.StoryCreateDto;
-import io.hexlet.cv.dto.marketing.StoryUpdateDto;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.openapitools.jackson.nullable.JsonNullable;
-import org.springframework.http.MediaType;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -18,6 +10,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
+import io.hexlet.cv.dto.marketing.StoryCreateDto;
+import io.hexlet.cv.dto.marketing.StoryUpdateDto;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.http.MediaType;
 
 /**
  * Создание и обновление историй через {@code POST/PUT /admin/marketing/stories}:
@@ -56,7 +56,7 @@ public class AdminMarketingStoriesControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.title").exists());
     }
 
@@ -70,7 +70,7 @@ public class AdminMarketingStoriesControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.showOnHomepage").exists());
     }
 
@@ -86,7 +86,7 @@ public class AdminMarketingStoriesControllerTest extends AdminMarketingControlle
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.imageUrl").exists());
     }
 

--- a/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingTeamControllerTest.java
+++ b/src/test/java/io/hexlet/cv/controller/admin/marketing/AdminMarketingTeamControllerTest.java
@@ -1,15 +1,5 @@
 package io.hexlet.cv.controller.admin.marketing;
 
-import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
-import io.hexlet.cv.dto.marketing.TeamCreateDto;
-import io.hexlet.cv.dto.marketing.TeamUpdateDto;
-import io.hexlet.cv.model.enums.TeamMemberType;
-import io.hexlet.cv.model.enums.TeamPosition;
-import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentCaptor;
-import org.openapitools.jackson.nullable.JsonNullable;
-import org.springframework.http.MediaType;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -20,6 +10,16 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import io.hexlet.cv.controller.admin.marketing.support.AdminMarketingControllerTestSupport;
+import io.hexlet.cv.dto.marketing.TeamCreateDto;
+import io.hexlet.cv.dto.marketing.TeamUpdateDto;
+import io.hexlet.cv.model.enums.TeamMemberType;
+import io.hexlet.cv.model.enums.TeamPosition;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.openapitools.jackson.nullable.JsonNullable;
+import org.springframework.http.MediaType;
 
 /**
  * Создание и обновление участников команды через {@code POST/PUT /admin/marketing/team}:
@@ -62,7 +62,7 @@ public class AdminMarketingTeamControllerTest extends AdminMarketingControllerTe
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.firstName").exists());
     }
 
@@ -78,7 +78,7 @@ public class AdminMarketingTeamControllerTest extends AdminMarketingControllerTe
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.position").exists());
     }
 
@@ -94,7 +94,7 @@ public class AdminMarketingTeamControllerTest extends AdminMarketingControllerTe
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper().writeValueAsString(dto))
                         .with(user(ADMIN).roles(ROLE_ADMIN)))
-                .andExpect(status().isUnprocessableEntity())
+                .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.errors.memberType").exists());
     }
 


### PR DESCRIPTION
Задача: https://github.com/hexlet-volunteers/hexlet-cv/issues/1220

Что сделано:
- проверены контроллеры на наличие `@Valid` перед входными параметрами; 
- добавлены `@Size` на поля DTO; для DTO аутентификации сообщения валидации добавлены в properties-файлы.
- включён FAIL_ON_UNKNOWN_PROPERTIES в JacksonConfig;
- проверены все репозитории, конкатенации не найдено, все запросы параметризованные;
- изменен статус в обработчике ошибок валидации, теперь он возвращает 400, добавлена обработка ошибок валидации класса.
- добавлена обработка неизвестных полей в JSON
- разделены файлы локализации по категориям: общие сообщения вынесены в messages/common, сообщения ошибок в messages/validation, настроена их подгрузка в LocaleConfig