### PR TITLE
Feat #1217 Backend: security-заголовки (CSP, HSTS, X-Frame-Options и др.)

### DIFF
--- a/src/main/java/io/hexlet/cv/config/SecurityConfig.java
+++ b/src/main/java/io/hexlet/cv/config/SecurityConfig.java
@@ -31,6 +31,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -64,7 +65,17 @@ public class SecurityConfig {
                         .jwt(jwt -> jwt
                                 .decoder(jwtDecoder)
                                 .jwtAuthenticationConverter(jwtAuthConverter)
-                        ));
+                        ))
+                .headers(headers -> headers
+                        .frameOptions(frameOptions -> frameOptions.deny())
+                        .referrerPolicy(referrer -> referrer
+                                .policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.SAME_ORIGIN))
+                        .permissionsPolicyHeader(permissions -> permissions
+                                .policy("geolocation=(), camera=(), microphone=()"))
+                        .httpStrictTransportSecurity(hsts -> hsts
+                                .maxAgeInSeconds(31536000)
+                                .includeSubDomains(true))
+                );
         return http.build();
     }
 

--- a/src/main/java/io/hexlet/cv/config/SecurityConfig.java
+++ b/src/main/java/io/hexlet/cv/config/SecurityConfig.java
@@ -75,7 +75,20 @@ public class SecurityConfig {
                         .httpStrictTransportSecurity(hsts -> hsts
                                 .maxAgeInSeconds(31536000)
                                 .includeSubDomains(true))
-                );
+                        .contentSecurityPolicy(csp -> csp
+                                .policyDirectives(
+                                        "default-src 'self'; "
+                                                + "script-src 'self'; "
+                                                + "style-src 'self' 'unsafe-inline'; "
+                                                + "img-src 'self' data:; "
+                                                + "font-src 'self'; "
+                                                + "connect-src 'self'; "
+                                                + "frame-ancestors 'none'; "
+                                                + "base-uri 'self'; "
+                                                + "form-action 'self'; "
+                                                + "object-src 'none'"
+                                )
+                        ));
         return http.build();
     }
 


### PR DESCRIPTION
**Задача: #1217** 

Проблема: отсутствие security-заголовков открывает XSS, clickjacking, MIME-sniffing и утечку referrer.

**Что сделано:**

Добавлена явная настройка security headers через Spring Security:

- X-Frame-Options: DENY
- Referrer-Policy: same-origin
- Permissions-Policy с запретом геолокации, камеры и микрофона
- HSTS на 1 год с includeSubDomains
- Content-Security-Policy с deny-by-default подходом:
  - ресурсы по умолчанию разрешены только с текущего origin;
  - JavaScript разрешён только с 'self', без inline scripts;
  - стили разрешены с 'self' и inline styles;
  - изображения — с 'self' и через data:;
  - шрифты и сетевые подключения — только с 'self';
  - запрещено встраивание страницы через frame-ancestors 'none';
  - base-uri и form-action ограничены текущим origin;
  - object-src полностью запрещён.

**Возможные проблемы и уточнения:**

- CSP проверена на текущей прод-сборке фронта через Vite preview. При style-src 'self' фронт генерирует CSP violations из-за inline стилей, поэтому добавлен 'unsafe-inline'. Возможно, стоит обсудить с фронтэнд-командой более строгий вариант, например nonce.
- Стоит ли оставлять includeSubDomains для HSTS, если нет гарантии, что все будущие поддомены будут работать исключительно по HTTPS?
- Нужно ли добавить отдельные интеграционные тесты, проверяющие наличие и значения security headers?