### PR TITLE
chore: удалить артефакт firstPR.txt и раздел про первый PR

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,26 +64,5 @@
 
 [Подробные инструкции по работе с PR](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests)
 
-## Создание первого pull request
-* Создать ветку ( например firstPR )
-    ```bash
-    git checkout -b firstPR
-    ```
-* В файл FirstPR.txt написать приветственную фразу ( например Hello world ).
-* Закоммитеть изменения:
-    ```bash
-    git add . && git commit -m "This is the first PR"
-    git push --set-upstream origin firstPR
-    ```
-* Зайти на [основной репозиторий](https://github.com/Hexlet/hexlet-cv)  и создайть PR
-
-После того как PR будет принят, можно будет вернуться на ветку main, [обновить](https://docs.github.com/ru/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork) репозитории и удалить ветку firstPR
-
-    ```bash
-    git checkout main
-    git pull 
-    git branch -d firstPR 
-    ```
-
 ### Спасибо за помощь `!`
 

--- a/firstPR.txt
+++ b/firstPR.txt
@@ -1,2 +1,0 @@
-My first PR!!
-.


### PR DESCRIPTION
## Что удалено

* `firstPR.txt` — файл-артефакт из онбординга новичков, внутри лежало `My first PR!!` и точка.
* Раздел «Создание первого pull request» из `CONTRIBUTING.md` (21 строка). Он предлагал завести ветку `firstPR`, написать приветственную фразу в `FirstPR.txt` и отправить PR — без файла инструкция вела бы в никуда.

Общий раздел «Создание pull request» с рабочим порядком (ветка → коммит → PR → синхронизация форка) остался на месте.

## Замечание

Онбординг-поток ещё живой: прямо сейчас открыт #1277 из ветки `firstPR`. Если тренировочный первый PR решено сохранить как практику, стоит не удалять раздел, а переписать его — например, на правку строки в `CONTRIBUTING.md` или на добавление себя в список участников, без служебного файла в корне репозитория. Скажите, если нужен такой вариант, — переделаю.
