### PR TITLE
fix: отдавать 404 вместо 500 на несуществующие пути [issue #1286]

### DIFF
--- a/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
+++ b/src/main/java/io/hexlet/cv/handler/GlobalExceptionHandler.java
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 import org.springframework.web.servlet.view.RedirectView;
 
 @Slf4j
@@ -100,6 +101,15 @@ public class GlobalExceptionHandler {
                                                   RedirectAttributes redirectAttributes) {
 
         Map<String, String> errors = Map.of("error", ex.getMessage());
+        return commonHandle(errors, request, redirectAttributes, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public Object handleNoResourceFound(NoResourceFoundException ex,
+                                        HttpServletRequest request,
+                                        RedirectAttributes redirectAttributes) {
+
+        Map<String, String> errors = Map.of("error", "Resource not found");
         return commonHandle(errors, request, redirectAttributes, HttpStatus.NOT_FOUND);
     }
 

--- a/src/test/java/io/hexlet/cv/handler/NotFoundHandlingTest.java
+++ b/src/test/java/io/hexlet/cv/handler/NotFoundHandlingTest.java
@@ -1,0 +1,106 @@
+package io.hexlet.cv.handler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import io.hexlet.cv.audit.AuditEventType;
+import io.hexlet.cv.audit.support.AuditLogCaptureSupport;
+import io.hexlet.cv.service.PageSectionService;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class NotFoundHandlingTest extends AuditLogCaptureSupport {
+
+    private static final String UNKNOWN_PATH = "/api/not-the-path-you-are-looking-for";
+    private static final String FAILURE_DETAIL = "internal-detail-iddqd";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoSpyBean
+    private PageSectionService pageSectionService;
+
+    private Logger handlerLogger;
+    private ListAppender<ILoggingEvent> handlerAppender;
+
+    @Override
+    protected List<String> secretMarkers() {
+        return List.of(FAILURE_DETAIL);
+    }
+
+    @BeforeEach
+    void attachHandlerAppender() {
+        handlerAppender = new ListAppender<>();
+        handlerAppender.start();
+
+        handlerLogger = (Logger) LoggerFactory.getLogger(GlobalExceptionHandler.class);
+        handlerLogger.addAppender(handlerAppender);
+    }
+
+    @AfterEach
+    void detachHandlerAppender() {
+        handlerLogger.detachAppender(handlerAppender);
+        handlerAppender.stop();
+    }
+
+    @Test
+    void shouldReturnNotFoundForUnknownPath() throws Exception {
+        mockMvc.perform(get(UNKNOWN_PATH))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void shouldNotWriteAuditEventForUnknownPath() throws Exception {
+        mockMvc.perform(get(UNKNOWN_PATH));
+
+        assertThat(capturedLines())
+                .as("скан несуществующих путей не должен засорять журнал аудита")
+                .isEmpty();
+    }
+
+    @Test
+    void shouldNotLogErrorForUnknownPath() throws Exception {
+        mockMvc.perform(get(UNKNOWN_PATH));
+
+        assertThat(handlerAppender.list)
+                .as("отсутствие ресурса не ошибка сервера, стек в error-логе прячет настоящие поломки")
+                .noneMatch(event -> event.getLevel() == Level.ERROR);
+    }
+
+    @Test
+    void shouldStillReportServerErrorForRealFailure() throws Exception {
+        doThrow(new IllegalStateException(FAILURE_DETAIL))
+                .when(pageSectionService).findAllOnPage(anyString(), any());
+
+        mockMvc.perform(get("/"))
+                .andExpect(status().isInternalServerError());
+
+        assertThat(handlerAppender.list)
+                .as("настоящая поломка обязана остаться видимой в error-логе")
+                .anyMatch(event -> event.getLevel() == Level.ERROR);
+
+        assertThat(capturedLines())
+                .as("настоящая поломка обязана остаться в журнале аудита")
+                .anyMatch(line -> line.contains(AuditEventType.UNHANDLED_ERROR.name()));
+    }
+}


### PR DESCRIPTION
## Несуществующий путь отдаёт 404, а не 500

Refs #1286

`NoResourceFoundException` доходил до общего `@ExceptionHandler(Exception.class)`
в `GlobalExceptionHandler`. Это исключение означает «нет такого ресурса», но
обработчик отвечал 500, писал `log.error` со стеком и — после мержа аудита
(#1223) — заводил ещё и событие `UNHANDLED_ERROR` / `SERVER_ERROR`. Любой сканер
путей забивал оба журнала, и настоящая поломка терялась в этом потоке.

**Что сделано:** отдельный обработчик `NoResourceFoundException` → 404 через
общий `commonHandle`, без записи в error-лог и без события аудита. Настоящие
внутренние ошибки по-прежнему идут через `handleAll`: 500, стек в логе, запись
в журнале аудита.

## Осознанные решения

- Тело ответа — generic `"Resource not found"`, а не `ex.getMessage()`. Сообщение
  исключения выглядит как `No static resource api/vacancies.` и раскрывает, что
  путь дошёл до обработчика статики; требование generic-ответа из закрытого #1082
  при этом сохраняется.
- `NoHandlerFoundException` из предложенного в задаче списка не обрабатывается.
  В текущей конфигурации до него дело не доходит: несопоставленный путь
  перехватывает `ResourceHttpRequestHandler` и бросает `NoResourceFoundException` —
  это видно по красному тесту, который до фикса падал именно на нём. Обработчик
  на второе исключение был бы кодом, который нечем покрыть; если конфигурация
  изменится (`spring.web.resources.add-mappings: false`), его нужно будет добавить
  вместе с тестом.
- Регрессия на 500 проверена не только тем, что тест зелёный: при временно
  заглушённом `log.error` в `handleAll` он падает.

## Тесты

`NotFoundHandlingTest` — 4 теста:

- `shouldReturnNotFoundForUnknownPath` — 404 вместо 500 (`Status expected:<404> but was:<500>`);
- `shouldNotWriteAuditEventForUnknownPath` — в журнале аудита пусто (до фикса —
  `[AUDIT] event=UNHANDLED_ERROR ... path=/api/...`);
- `shouldNotLogErrorForUnknownPath` — нет записи уровня ERROR в логе обработчика;
- `shouldStillReportServerErrorForRealFailure` — настоящая ошибка по-прежнему
  отдаёт 500, пишет стек и попадает в аудит. Ошибка эмулируется через
  `@MockitoSpyBean` на `PageSectionService` и публичный `GET /`, то есть проверка
  идёт через ту же HTTP-границу, а не вызовом обработчика напрямую.

## Проверки

- `make check` — 301 тест, все зелёные.
- `make lint` — 42 нарушения в `main` и 237 в `test`, все предсуществующие
  (#1274). В изменённых файлах — 0. `spotlessCheck` тоже падает только на чужих
  файлах (#1275).