### PR TITLE
Use namespaced DB credentials (DB_USERNAME/DB_PASSWORD) [issue #1287]

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,8 @@ RSA_PUBLIC_KEY_PATH=file:/etc/secrets/public.pem
 
 # === База данных (prod) ===
 JDBC_DATABASE_URL=jdbc:postgresql://localhost:5432/hexlet_cv
-USERNAME=hexlet
-PASSWORD=
+DB_USERNAME=hexlet
+DB_PASSWORD=
 
 # === Интеграции (задел на будущее, в коде пока нет) ===
 HH_API_TOKEN=

--- a/docs/RENDER_DEPLOY.md
+++ b/docs/RENDER_DEPLOY.md
@@ -34,7 +34,7 @@
 
 ## Шаг 2. Создать Web Service (Docker)
 
-Данные для переменных окружения (шаг 3) возьмите из карточки PostgreSQL, созданной в шаге 1. Если использовали примеры выше — `USERNAME` = `hexlet_cv_user`, `DATABASE` = `hexlet_cv`, `HOST` — из **Info** в карточке БД.
+Данные для переменных окружения (шаг 3) возьмите из карточки PostgreSQL, созданной в шаге 1. Если использовали примеры выше — `DB_USERNAME` = `hexlet_cv_user`, `DATABASE` = `hexlet_cv`, `HOST` — из **Info** в карточке БД.
 
 1. В Dashboard нажмите **New** → **Web Service**.
 2. Подключите репозиторий:
@@ -58,8 +58,8 @@
 | :---------------------- |:-------------------------------------------------------------------------------------| :-------------------------------- |
 | `SPRING_PROFILES_ACTIVE` | `prod`                                                                               | Включение продакшен-конфигурации  |
 | `JDBC_DATABASE_URL`     | `jdbc:postgresql://{Hostname}:{Port}/{Database}?password={Password}&user={Username}` | Полный JDBC URL (подставьте HOST, PASSWORD и USER из карточки БД) |
-| `USERNAME`              | `hexlet_cv_user`                                                                     | Из карточки PostgreSQL (см. шаг 1) |
-| `PASSWORD`              | *ваш пароль из шага 1*                                                               | Из карточки PostgreSQL            |
+| `DB_USERNAME`           | `hexlet_cv_user`                                                                     | Из карточки PostgreSQL (см. шаг 1) |
+| `DB_PASSWORD`           | *ваш пароль из шага 1*                                                               | Из карточки PostgreSQL            |
 | `DATABASE`              | `hexlet_cv_db`                                                                       | Из карточки PostgreSQL (см. шаг 1) |
 | `HOST`                  | `dpg-xxx123-a`                                                                       | Internal hostname из карточки БД  |
 | `DB_PORT`               | `5432`                                                                               | Порт PostgreSQL                   |
@@ -128,11 +128,11 @@ services:
     envVars:
       - key: SPRING_PROFILES_ACTIVE
         value: prod
-      - key: USERNAME
+      - key: DB_USERNAME
         fromDatabase:
           name: hexlet-cv-db
           property: user
-      - key: PASSWORD
+      - key: DB_PASSWORD
         fromDatabase:
           name: hexlet-cv-db
           property: password

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -7,8 +7,8 @@ spring:
   datasource:
     url:  ${JDBC_DATABASE_URL}
     driver-class-name: org.postgresql.Driver
-    username: ${USERNAME}
-    password: ${PASSWORD}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
 
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
Что было:
В application-prod.yml учетные данные базы данных читались из переменных с общими именами USERNAME и PASSWORD. Возникала проблема: переменную USERNAME часто выставляет сама система (например, Windows, WSL или агенты CI), из-за чего приложение молча подключалось к базе данных под чужим именем вместо логина из секретов.

Что сделано:
Переименовал переменные в более специфичные DB_USERNAME и DB_PASSWORD
application-prod.yml — USERNAME заменено на DB_USERNAME, PASSWORD заменено на DB_PASSWORD
.env.example — обновлены ключи 
docs/RENDER_DEPLOY.md — обновлена таблица переменных, пример в шаге 2 и файл render.yaml

Критерии приемки выполнены. В application-prod.yml больше нет USERNAME и PASSWORD, вся документация обновлена. Изменения не меняют логику приложения, а только переименовывают переменные окружения.

Refs #1287